### PR TITLE
Allowing sedumi's numerical errors flag to count as primal feasible.

### DIFF
--- a/spotopt/@spotprogsol/spotprogsol.m
+++ b/spotopt/@spotprogsol/spotprogsol.m
@@ -28,7 +28,7 @@ classdef spotprogsol
 
         function feas = statusIsDualFeasible(status)
             feas = (status == spotsolstatus.STATUS_PRIMAL_AND_DUAL_FEASIBLE ...
-                    | status == spotsolstatus.STATUS_PRIMAL_INFEASIBLE);
+                    | status == spotsolstatus.STATUS_PRIMAL_INFEASIBLE | status == spotsolstatus.STATUS_NUMERICAL_PROBLEMS);
         end
     end
 


### PR DESCRIPTION
As we discussed, sedumi's "numerical errors" flag wouldn't allow us to extract solutions. I've changed spotprogsol.m to allow us to extract solutions even with this flag.
