### PR TITLE
When the primal/dual is infeasible, we now return [] instead of NaN*ones

### DIFF
--- a/spotopt/solvers/spot_mosek.m
+++ b/spotopt/solvers/spot_mosek.m
@@ -166,15 +166,15 @@ function [x,y,z,info] = spot_mosek(A,b,c,K,options)
 
         end
     else
-        x = NaN*ones(n,1);
+        x = []; % NaN*ones(n,1);
     end
     
     if spotprogsol.statusIsDualFeasible(status)
         y = res.sol.itr.y;
         z = c-A'*y;
     else
-        y = NaN*ones();
-        z = NaN*ones();
+        y = []; % NaN*ones();
+        z = []; % NaN*ones();
     end
     
     info.solverName = 'mosek';


### PR DESCRIPTION
This is to prevent Out of Memory errors on very large problems (e.g., with DSOS). Having the output be a dense vector of NaNs causes Matlab to give a OOM error.

I double checked that this does not cause any problems further down the pipeline. 
