### PR TITLE
remove a vectorization

### DIFF
--- a/@msspoly/msspoly.m
+++ b/@msspoly/msspoly.m
@@ -60,7 +60,7 @@ classdef (InferiorClasses = {?double}) msspoly
                   case 'msspoly',
                     p = x;
                   case 'double',
-                    if any(isnan(x(:)) | isinf(x(:)))
+                    if any(any((isnan(x)) | isinf(x)))
                         error('infinite coefficients not permitted');
                     end
                     p.dim = size(x);


### PR DESCRIPTION
When SOS is large, the vectorization `x(:)` raises the error
`Matrix is too large to convert to linear index`