### PR TITLE
display the error message that mosek produces when it throws an error

### DIFF
--- a/spotopt/solvers/spot_mosek.m
+++ b/spotopt/solvers/spot_mosek.m
@@ -138,6 +138,7 @@ function [x,y,z,info] = spot_mosek(A,b,c,K,options)
     [info.ctime,info.wtime] = spot_etime(spot_now(),start);
 
     if ~isfield(res, 'sol')
+        warning('Spotless:SpotMosek:MosekError', 'Mosek produced the following error message: "%s" (%s)', res.rmsg, res.rcodestr);
         status = spotsolstatus.STATUS_SOLVER_ERROR;
     else
         switch res.sol.itr.prosta


### PR DESCRIPTION
Currently, when mosek returns an error code, the actual error message is lost (this typically happens when, for example, the mosek license has expired). This change prints the Mosek internal error as a warning so that the user can address it. 

