### PR TITLE
subsasgn for msspoly - Handle Empty Vector properly

### DIFF
--- a/@msspoly/subsasgn.m
+++ b/@msspoly/subsasgn.m
@@ -31,7 +31,11 @@ switch s.type
     else
 
         switch length(s.subs)
-          case 1,
+          case 1
+            if(numel(s.subs{1}) == 0)
+              q = p1;
+              return
+            end
             p2 = indexinto(p2,':');
             ind = s.subs{1};
             ind = ind(:);
@@ -65,9 +69,14 @@ switch s.type
             end
             dim = p1.dim;
             
-          case 2,
+          case 2
             % We are given two subscript arrays.
             % First lets normalize the subscript arrays.
+            if(numel(s.subs{1}) == 0 || numel(s.subs{2}) == 0)
+              q = p1;
+              return
+            end
+            
             if iscolon(s.subs{1}), is = (1:p1.dim(1))';
             else, is = s.subs{1}(:); end
             

--- a/tests/msspoly_subsasgn_test.m
+++ b/tests/msspoly_subsasgn_test.m
@@ -1,0 +1,15 @@
+nq = 3;
+q=msspoly('q',nq);
+s=msspoly('s',nq);
+c=msspoly('c',nq);
+qt=TrigPoly(q,s,c);
+
+J = zeros(3,3) * qt(1)
+
+pos_row_indices = 1:3;
+
+v_or_qdot_indices = zeros(0,1);
+
+Jpos = zeros(3,0);
+
+J(pos_row_indices, v_or_qdot_indices) = Jpos


### PR DESCRIPTION
The test example in  "msspoly_subsasgn_test.m" shows that subsasgn for msspoly was not able to handle a subsasgn call of this type: v(1:3, zeros(0,1)) 
This pull request should fix this now.